### PR TITLE
CVE-2020-7206: Fix php code injection problem

### DIFF
--- a/action-url/nagios_hpeilo_service_details.php
+++ b/action-url/nagios_hpeilo_service_details.php
@@ -22,7 +22,7 @@
         $ip=$_GET["ip"];
         $comm=$_GET["comm"];
         $id=$_GET["id"];
-        $cmd="./nagios_hpeilo_engine -H $ip -C $comm -o $id -J";
+        $cmd=escapeshellcmd("./nagios_hpeilo_engine -H $ip -C $comm -o $id -J");
         $ret = exec($cmd,$output);
         echo join("\n",$output);
 ?>


### PR DESCRIPTION
Add escapeshellcmd() to check the embed strings, for resolving
php code injection problem in nagios-plugins-hpilo, reported
by Numan Turle, CVE-2020-7206.